### PR TITLE
docs: typo in options to modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Modali provides an easy to use interface for accessing useful events, such as wh
 | `onShow` | Called when the component finishes mounting to the DOM |
 | `onHide` | Called when the component is removed from the DOM |
 | `onEscapeKeyDown` | Called when the escape key is pressed while the component is mounted to the DOM |
-| `onOverlayClick` | Called when the modal overlay back is clicked while the component is mounted to the DOM |
+| `onOverlayClicked` | Called when the modal overlay back is clicked while the component is mounted to the DOM |
 
 Example
 


### PR DESCRIPTION
In the code this option is called `onOverlayClicked`:
https://github.com/upmostly/modali/blob/master/src/index.js#L55-L57