### PR TITLE
Fix close button when modal is centered

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ const Modal = ({
   isModalVisible, hide, options, children,
 }) => {
   function handleOverlayClicked(e) {
-    if (e.target.className !== 'modali-wrapper') {
+    if (!e.target.className.startsWith('modali-wrapper')) {
       return;
     }
     if (options === undefined) {


### PR DESCRIPTION
Fix close overlay when modal is centered issue created here https://github.com/upmostly/modali/issues/40